### PR TITLE
Add constraints for positive pricing and stock

### DIFF
--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -55,8 +55,8 @@ CREATE TABLE referencia (
     REFERENCES vinyeta(id)
     ON DELETE CASCADE,
   sku VARCHAR(100),
-  precio NUMERIC(10,2),
-  stock INTEGER
+  precio NUMERIC(10,2) CHECK (precio >= 0),
+  stock INTEGER CHECK (stock >= 0)
 );
 
 -- 7. Atributo Diferenciador


### PR DESCRIPTION
## Summary
- prevent negative values for product references by adding CHECK constraints on price and stock

## Testing
- `psql --version` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*


------
https://chatgpt.com/codex/tasks/task_e_6896ee7aa524832d9c26296ab32e6400