### PR TITLE
Enforce positive price and defer stock tracking

### DIFF
--- a/migrations/001_create_tables.sql
+++ b/migrations/001_create_tables.sql
@@ -55,8 +55,7 @@ CREATE TABLE referencia (
     REFERENCES vinyeta(id)
     ON DELETE CASCADE,
   sku VARCHAR(100),
-  precio NUMERIC(10,2),
-  stock INTEGER
+  precio NUMERIC(10,2) CHECK (precio >= 0)
 );
 
 -- 7. Atributo Diferenciador


### PR DESCRIPTION
## Summary
- remove the `stock` column from `referencia` until inventory support is needed
- keep check constraint so `precio` cannot be negative

## Testing
- `psql --version` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `apt-get install -y postgresql-client` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_6896ee7aa524832d9c26296ab32e6400